### PR TITLE
feat(circuit): adiciona verificação ZK da concentração de ingrediente

### DIFF
--- a/circuits/Nargo.toml
+++ b/circuits/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "zk_comply"
+type = "bin"
+authors = ["ZK_COMPLY"]
+version = "0.1.0"
+description = "ZK Circuit for composition verification"
+# compiler_version = "0.16.0"  # Opcional, mas recomendado
+
+[dependencies]

--- a/circuits/Prover.toml
+++ b/circuits/Prover.toml
@@ -1,0 +1,12 @@
+# Prover.toml - exemplo para teste local
+# Esse arquivo será sobrescrito pelo backend em tempo de execução
+
+[main]
+composition = [
+  9500, 90500, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+]
+composition_index = 0
+threshold = 10000
+hash_commitment = "0"  # deve ser calculado via pedersen_hash no backend

--- a/circuits/src/main.nr
+++ b/circuits/src/main.nr
@@ -1,0 +1,126 @@
+// Circuit for verifying composition of values with threshold and hash commitment
+// Inputs:
+// - composition: private array of 30 elements
+// - composition_index: public index for verification
+// - threshold: public limit value
+// - hash_commitment: public hash for verification
+
+fn main(
+    composition: [Field; 30],       // Private array with 30 elements
+    composition_index: u32,         // Public index for verification
+    threshold: u32,                 // Public limit value
+    hash_commitment: Field          // Public hash for verification
+) {
+    // 1. Verify if the index is within array bounds
+    assert(composition_index < 30);
+
+    // 2. Verify if the value at the specified index is less than the threshold
+    // Convert both values to u32 for comparison
+    let value = composition[composition_index] as u32;
+    assert(value < threshold);
+
+
+    // 3. Calculate the total sum of elements and verify if it equals 100000
+    let mut sum = 0;
+    for i in 0..30 {
+        sum += composition[i];
+    }
+    assert(sum == 100000);
+
+    // 4. Generate the hash of the composition and verify if it matches the commitment
+    let hash = std::hash::pedersen_hash(composition);
+    assert(hash == hash_commitment);
+}
+
+// Test for verifying a valid proof
+// This test simulates a scenario where:
+// - The composition has only one non-zero element (9500) at index 0
+// - The threshold is greater than the value at index 0 (10000)
+// - The total sum is 100000 (9500 + 29 zeros)
+// - The hash commitment is correctly calculated
+#[test]
+fn test_valid_proof() {
+    // Initialize the composition array with zeros
+    let mut composition = [0; 30];
+    composition[0] = 9500;
+    composition[1] = 90500; // completa os 100000 ppm
+
+
+    // Define public parameters
+    let composition_index = 0;
+    let threshold = 10000;
+
+    // Calculate the hash commitment using the composition
+    let hash_commitment = std::hash::pedersen_hash(composition);
+
+    // Execute the main circuit with the defined parameters
+    main(composition, composition_index, threshold, hash_commitment);
+}
+
+
+#[test]
+fn hash_debugger() {
+    let mut composition: [Field; 30] = [0; 30];
+    composition[0] = 9500;
+    composition[1] = 90500;
+
+    let hash: Field = std::hash::pedersen_hash(composition);
+    std::print(hash); // <- print hash value
+
+    assert(hash == 123); // <- forca falha pra mostrar saida
+}
+
+
+
+
+
+// Test for verifying an invalid proof
+// This test simulates a scenario where:
+// - The composition has a value (15000) greater than the threshold (10000)
+// - The test should fail at the threshold verification
+// #[test]
+// fn test_invalid_proof() {
+    // Initialize the composition array with zeros
+//    let mut composition = [0; 30];
+    // Set the value 15000 at index 0 (greater than the threshold)
+//    composition[0] = 15000;
+
+    // Define public parameters
+//    let composition_index = 0;
+//    let threshold = 10000;
+
+    // Calculate the hash commitment using the composition
+//    let hash_commitment = std::hash::pedersen_hash(composition);
+
+    // Execute the main circuit with the defined parameters
+    // Should fail because composition[0] > threshold
+//    main(composition, composition_index, threshold, hash_commitment);
+//}
+
+// Test to verify hash generation
+// This test ensures that the hash is generated correctly for a known input
+#[test]
+fn test_hash_generation() {
+    let mut composition = [0; 30];
+    composition[0] = 9500;
+
+    let hash = std::hash::pedersen_hash(composition);
+    // The hash should not be zero
+    assert(hash != 0);
+}
+
+// Notes about the types and functions used:
+//
+// 1. Field vs u32:
+//    - Field: Special type in Noir that represents elements of the finite field
+//             used in zero-knowledge proofs. Allows secure arithmetic operations
+//             in ZK and prevents overflow.
+//    - u32: 32-bit unsigned integer type. Used for public values that don't
+//           need ZK operations, such as indices and thresholds.
+//
+// 2. Pedersen Hash:
+//    - Cryptographic hash function secure for ZK
+//    - Preserves privacy: doesn't reveal information about the inputs
+//    - Resistant to collisions and preimage attacks
+//    - Efficient in zero-knowledge proofs
+//    - Allows verification of commitments without revealing original data


### PR DESCRIPTION
Closes #1 

Este PR adiciona o circuito principal Noir que:

- Verifica se `composition[index] < threshold`
- Valida a soma total de 100_000 ppm
- Compara o hash da fórmula com `hash_commitment`
- Inclui `hash_debugger` para extração manual do hash Pedersen

Esse circuito será usado pelo backend para geração de provas, garantindo confidencialidade na composição.
